### PR TITLE
Update to v1.1.0

### DIFF
--- a/OutgoingDamageLog/ModConfig.cs
+++ b/OutgoingDamageLog/ModConfig.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OutgoingDamageLog
+{
+    public class ModConfig
+    {
+        public bool PrintRemainingHP = false;
+    }
+}

--- a/OutgoingDamageLog/assets/outgoingdamagelog/lang/en.json
+++ b/OutgoingDamageLog/assets/outgoingdamagelog/lang/en.json
@@ -1,3 +1,7 @@
 {
-    "hello": "hello world!"
+  "slashing": "Slashing",
+  "piercing": "Piercing",
+  "blunt": "Blunt",
+  "unknown": "Unknown",
+  "damage-output": "Dealt {0} {1} damage to {2}"
 }

--- a/OutgoingDamageLog/modinfo.json
+++ b/OutgoingDamageLog/modinfo.json
@@ -3,10 +3,10 @@
     "modid": "outgoingdamagelog",
     "name": "OutgoingDamageLog",
     "authors": [
-        "Unknown"
+        "DessertOverlord"
     ],
-    "description": "To be added",
-    "version": "1.0.0",
+    "description": "Adds outgoing damage to the damage log.",
+    "version": "1.1.0",
     "dependencies": {
         "game": ""
     }


### PR DESCRIPTION
- Fix dmgSource.CauseEntity.Class null reference -- likely caused by entities damaged by blocks (I only added this to the if statement because of combat overhaul, damn you) -- thanks to @Kathanon on VSModDB
- Move SendMessage output to inner if statement -- thanks to @Kathanon on VSModDB
- Clean up 'if' statement code and reorder for efficiency
- Collapse unnecessary nested if statement
- Add localization -- thanks to @Kathanon on VSModDB for the quick lesson
- Remove unnecessary client initializations